### PR TITLE
함수명 수정

### DIFF
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -16,7 +16,7 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 scalar DateTime
 
 type Query {
-  getUser(id: Float!): UserOutput!
+  getUser(id: Int!): UserOutput!
 }
 
 type Mutation {

--- a/src/user/application/services/user.service.spec.ts
+++ b/src/user/application/services/user.service.spec.ts
@@ -107,7 +107,7 @@ describe('UserService', () => {
 
   describe('findUnique', () => {
     it('should return user when user exists', async () => {
-      const result = await service.findUniqeuee(1);
+      const result = await service.findUnique(1);
 
       expect(result).toBeDefined();
       expect(result?.id).toBe(1);
@@ -115,8 +115,8 @@ describe('UserService', () => {
     });
 
     it('should throw CustomNotFoundException when user does not exist', async () => {
-      await expect(service.findUniqeuee(999)).rejects.toThrow(CustomNotFoundException);
-      await expect(service.findUniqeuee(999)).rejects.toThrow('존재하지 않는 유저입니다');
+      await expect(service.findUnique(999)).rejects.toThrow(CustomNotFoundException);
+      await expect(service.findUnique(999)).rejects.toThrow('존재하지 않는 유저입니다');
     });
   });
 });

--- a/src/user/application/services/user.service.spec.ts
+++ b/src/user/application/services/user.service.spec.ts
@@ -107,7 +107,7 @@ describe('UserService', () => {
 
   describe('findUnique', () => {
     it('should return user when user exists', async () => {
-      const result = await service.findUniqeu(1);
+      const result = await service.findUniqeue(1);
 
       expect(result).toBeDefined();
       expect(result?.id).toBe(1);
@@ -115,8 +115,8 @@ describe('UserService', () => {
     });
 
     it('should throw CustomNotFoundException when user does not exist', async () => {
-      await expect(service.findUniqeu(999)).rejects.toThrow(CustomNotFoundException);
-      await expect(service.findUniqeu(999)).rejects.toThrow('존재하지 않는 유저입니다');
+      await expect(service.findUniqeue(999)).rejects.toThrow(CustomNotFoundException);
+      await expect(service.findUniqeue(999)).rejects.toThrow('존재하지 않는 유저입니다');
     });
   });
 });

--- a/src/user/application/services/user.service.ts
+++ b/src/user/application/services/user.service.ts
@@ -35,7 +35,7 @@ export class UserService {
     return this.userRepository.create(user);
   }
 
-  async findUniqeuee(id: number): Promise<UserEntity | null> {
+  async findUnique(id: number): Promise<UserEntity | null> {
     const user = await this.userRepository.findUniqueById(id);
     if (!user) throw new CustomNotFoundException('존재하지 않는 유저입니다');
 

--- a/src/user/application/services/user.service.ts
+++ b/src/user/application/services/user.service.ts
@@ -35,7 +35,7 @@ export class UserService {
     return this.userRepository.create(user);
   }
 
-  async findUniqeu(id: number): Promise<UserEntity | null> {
+  async findUniqeue(id: number): Promise<UserEntity | null> {
     const user = await this.userRepository.findUniqueById(id);
     if (!user) throw new CustomNotFoundException('존재하지 않는 유저입니다');
 

--- a/src/user/application/services/user.service.ts
+++ b/src/user/application/services/user.service.ts
@@ -35,7 +35,7 @@ export class UserService {
     return this.userRepository.create(user);
   }
 
-  async findUnique(id: number): Promise<UserEntity | null> {
+  async findUnique(id: number): Promise<UserEntity> {
     const user = await this.userRepository.findUniqueById(id);
     if (!user) throw new CustomNotFoundException('존재하지 않는 유저입니다');
 

--- a/src/user/presentation/resolvers/user.resolver.ts
+++ b/src/user/presentation/resolvers/user.resolver.ts
@@ -8,7 +8,7 @@ export class UserResolver {
   constructor(private readonly userService: UserService) {}
 
   @Query(() => UserOutput)
-  async getUser(@Args('id') id: number): Promise<UserOutput> {
+  async getUsre(@Args('id') id: number): Promise<UserOutput> {
     const user = await this.userService.findUniqeuee(id);
     return new UserOutput(user);
   }

--- a/src/user/presentation/resolvers/user.resolver.ts
+++ b/src/user/presentation/resolvers/user.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Args, Int, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { UserService } from '@user/application/services/user.service';
 import { CreateUserInput } from '@user/presentation/dto/input/create-user.input';
 import { UserOutput } from '@user/presentation/dto/output/user.output';
@@ -8,8 +8,8 @@ export class UserResolver {
   constructor(private readonly userService: UserService) {}
 
   @Query(() => UserOutput)
-  async getUsre(@Args('id') id: number): Promise<UserOutput> {
-    const user = await this.userService.findUniqeuee(id);
+  async getUser(@Args('id', { type: () => Int }) id: number): Promise<UserOutput> {
+    const user = await this.userService.findUnique(id);
     return new UserOutput(user);
   }
 

--- a/src/user/presentation/resolvers/user.resolver.ts
+++ b/src/user/presentation/resolvers/user.resolver.ts
@@ -9,7 +9,7 @@ export class UserResolver {
 
   @Query(() => UserOutput)
   async getUser(@Args('id') id: number): Promise<UserOutput> {
-    const user = await this.userService.findUniqeu(id);
+    const user = await this.userService.findUniqeue(id);
     return new UserOutput(user);
   }
 


### PR DESCRIPTION
함수명 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - GraphQL 사용자 조회 쿼리의 공개 필드명이 getUser에서 getUsre로 변경되었습니다. 기능 동작은 동일하지만 쿼리 이름이 바뀌어 기존 클라이언트 요청이 실패할 수 있습니다. 사용 중인 쿼리, 프래그먼트, 스키마 생성/인트로스펙션, SDK 코드 생성 등을 새 필드명으로 업데이트하세요. 배포 후 즉시 확인을 권장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->